### PR TITLE
Store CertificateResource as one unit

### DIFF
--- a/certmagic.go
+++ b/certmagic.go
@@ -499,3 +499,25 @@ var (
 
 // Maximum size for the stack trace when recovering from panics.
 const stackTraceBufferSize = 1024 * 128
+
+const (
+	// Storage mode controls the format in which certificates are stored in `Storage`.
+	//
+	// Formats:
+	// - legacy: Store cert, privkey and meta as three separate storage items (.cert, .key, .json).
+	// - bundle: Store cert, privkey and meta as a single, bundled storage item (.bundle).
+	//
+	// Modes:
+	// - legacy:     Store and load certificates in legacy format.
+	// - transition: Store and load certificates in legacy and bundle format.
+	// - bundle:     Store and load certificates in bundle format.
+	//
+	// In the transition mode, failures around reads and writes of the bundle are soft.
+	// They should only log errors and try to work with the legacy format as fallback.
+	// Operations on the legacy format are hard-failures, implying that errors should be propagated up.
+	StorageModeEnv = "CERTMAGIC_STORAGE_MODE"
+
+	StorageModeLegacy     = "legacy"
+	StorageModeTransition = "transition"
+	StorageModeBundle     = "bundle"
+)

--- a/certmagic.go
+++ b/certmagic.go
@@ -515,6 +515,8 @@ const (
 	// In the transition mode, failures around reads and writes of the bundle are soft.
 	// They should only log errors and try to work with the legacy format as fallback.
 	// Operations on the legacy format are hard-failures, implying that errors should be propagated up.
+	//
+	// The storage mode is controlled via the CERTMAGIC_STORAGE_MODE environment variable
 	StorageModeEnv = "CERTMAGIC_STORAGE_MODE"
 
 	StorageModeLegacy     = "legacy"

--- a/certmagic.go
+++ b/certmagic.go
@@ -509,7 +509,7 @@ const (
 	//
 	// Modes:
 	// - legacy:     Store and load certificates in legacy format.
-	// - transition: Store and load certificates in legacy and bundle format.
+	// - transition: Store in legacy and bundle format, load as bundle with fallback to legacy format.
 	// - bundle:     Store and load certificates in bundle format.
 	//
 	// In the transition mode, failures around reads and writes of the bundle are soft.

--- a/config.go
+++ b/config.go
@@ -1276,10 +1276,7 @@ func (cfg *Config) storageHasCertResources(ctx context.Context, issuer Issuer, d
 		if cfg.storageHasCertResourcesBundle(ctx, issuer, domain) {
 			return true
 		}
-		if cfg.storageHasCertResourcesLegacy(ctx, issuer, domain) {
-			return true
-		}
-		return false
+		return cfg.storageHasCertResourcesLegacy(ctx, issuer, domain)
 	case StorageModeBundle:
 		return cfg.storageHasCertResourcesBundle(ctx, issuer, domain)
 	default:

--- a/config.go
+++ b/config.go
@@ -704,7 +704,7 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 		}
 		err = cfg.saveCertResource(ctx, issuerUsed, certRes)
 		if err != nil {
-			return fmt.Errorf("[%s] Obtain: saving assets: %v", name, err)
+			return fmt.Errorf("[%s] Renew: saving assets: %v", name, err)
 		}
 
 		log.Info("certificate obtained successfully",

--- a/config.go
+++ b/config.go
@@ -1102,7 +1102,8 @@ func (cfg *Config) RevokeCert(ctx context.Context, domain string, reason int, in
 			return err
 		}
 
-		if !cfg.Storage.Exists(ctx, StorageKeys.SitePrivateKey(issuerKey, domain)) {
+		// loadCertResource should already fail if private key is missing.
+		if len(certRes.PrivateKeyPEM) == 0 {
 			return fmt.Errorf("private key not found for %s", certRes.SANs)
 		}
 

--- a/config.go
+++ b/config.go
@@ -753,8 +753,7 @@ func (cfg *Config) reusePrivateKey(ctx context.Context, domain string) (privKey 
 
 	for i, issuer := range issuers {
 		// see if this issuer location in storage has a private key for the domain
-		privateKeyStorageKey := StorageKeys.SitePrivateKey(issuer.IssuerKey(), domain)
-		privKeyPEM, err = cfg.Storage.Load(ctx, privateKeyStorageKey)
+		certRes, err := cfg.loadCertResource(ctx, issuer, domain)
 		if errors.Is(err, fs.ErrNotExist) {
 			err = nil // obviously, it's OK to not have a private key; so don't prevent obtaining a cert
 			continue
@@ -762,6 +761,7 @@ func (cfg *Config) reusePrivateKey(ctx context.Context, domain string) (privKey 
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("loading existing private key for reuse with issuer %s: %v", issuer.IssuerKey(), err)
 		}
+		privKeyPEM = certRes.PrivateKeyPEM
 
 		// we loaded a private key; try decoding it so we can use it
 		privKey, err = PEMDecodePrivateKey(privKeyPEM)

--- a/config.go
+++ b/config.go
@@ -704,7 +704,7 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 		}
 		err = cfg.saveCertResource(ctx, issuerUsed, certRes)
 		if err != nil {
-			return fmt.Errorf("[%s] Renew: saving assets: %v", name, err)
+			return fmt.Errorf("[%s] Obtain: saving assets: %v", name, err)
 		}
 
 		log.Info("certificate obtained successfully",

--- a/config.go
+++ b/config.go
@@ -1268,9 +1268,9 @@ func (cfg *Config) checkStorage(ctx context.Context) error {
 	return nil
 }
 
-// storageHasCertResources returns true if the storage
-// associated with cfg's certificate cache has all the
+// storageHasCertResources returns true if the storage associated with cfg's certificate cache has all the
 // resources related to the certificate for domain.
+// It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) storageHasCertResources(ctx context.Context, issuer Issuer, domain string) bool {
 	switch os.Getenv(StorageModeEnv) {
 	case StorageModeTransition:
@@ -1311,6 +1311,7 @@ func (cfg *Config) storageHasCertResourcesBundle(ctx context.Context, issuer Iss
 // deleteSiteAssets deletes the folder in storage containing the
 // certificate, private key, and metadata file for domain from the
 // issuer with the given issuer key.
+// It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) deleteSiteAssets(ctx context.Context, issuerKey, domain string) error {
 	switch os.Getenv(StorageModeEnv) {
 	case StorageModeTransition:

--- a/config_test.go
+++ b/config_test.go
@@ -253,7 +253,7 @@ func TestStorageModeLegacy(t *testing.T) {
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SitePrivateKey(issuerKey, domain), true)
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteCert(issuerKey, domain), true)
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteMeta(issuerKey, domain), true)
-	assertFileExists(t, ctx, cfg.Storage, StorageKeys.CertificateResource(issuerKey, domain), false)
+	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteBundle(issuerKey, domain), false)
 
 	loaded, err := cfg.loadCertResource(ctx, am, domain)
 	if err != nil {
@@ -275,7 +275,7 @@ func TestStorageModeBundle(t *testing.T) {
 	}
 
 	issuerKey := am.IssuerKey()
-	assertFileExists(t, ctx, cfg.Storage, StorageKeys.CertificateResource(issuerKey, domain), true)
+	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteBundle(issuerKey, domain), true)
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SitePrivateKey(issuerKey, domain), false)
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteCert(issuerKey, domain), false)
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteMeta(issuerKey, domain), false)
@@ -304,7 +304,7 @@ func TestStorageModeTransition(t *testing.T) {
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SitePrivateKey(issuerKey, domain), true)
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteCert(issuerKey, domain), true)
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteMeta(issuerKey, domain), true)
-	assertFileExists(t, ctx, cfg.Storage, StorageKeys.CertificateResource(issuerKey, domain), true)
+	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteBundle(issuerKey, domain), true)
 
 	loaded, err := cfg.loadCertResource(ctx, am, domain)
 	if err != nil {
@@ -329,7 +329,7 @@ func TestStorageModeTransitionFallback(t *testing.T) {
 
 	issuerKey := am.IssuerKey()
 	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SitePrivateKey(issuerKey, domain), true)
-	assertFileExists(t, ctx, cfg.Storage, StorageKeys.CertificateResource(issuerKey, domain), false)
+	assertFileExists(t, ctx, cfg.Storage, StorageKeys.SiteBundle(issuerKey, domain), false)
 
 	// Switch to transition mode and verify fallback to legacy works
 	os.Setenv(StorageModeEnv, StorageModeTransition)

--- a/config_test.go
+++ b/config_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestSaveCertResource(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	am := &ACMEIssuer{CA: "https://example.com/acme/directory"}
 	testConfig := &Config{
@@ -211,7 +211,7 @@ func assertCertResourceContent(t *testing.T, loaded CertificateResource, expecte
 }
 
 func TestStorageModeLegacy(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, am := testStorageModeSetup(t, StorageModeLegacy, "./_testdata_tmp_legacy")
 
 	domain := "example.com"
@@ -235,7 +235,7 @@ func TestStorageModeLegacy(t *testing.T) {
 }
 
 func TestStorageModeBundle(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, am := testStorageModeSetup(t, StorageModeBundle, "./_testdata_tmp_bundle")
 
 	domain := "example.com"
@@ -259,7 +259,7 @@ func TestStorageModeBundle(t *testing.T) {
 }
 
 func TestStorageModeTransition(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, am := testStorageModeSetup(t, StorageModeTransition, "./_testdata_tmp_transition")
 
 	domain := "example.com"
@@ -284,7 +284,7 @@ func TestStorageModeTransition(t *testing.T) {
 }
 
 func TestStorageModeTransitionFallback(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, am := testStorageModeSetup(t, StorageModeTransition, "./_testdata_tmp_transition_fallback")
 
 	domain := "example.com"

--- a/config_test.go
+++ b/config_test.go
@@ -156,10 +156,9 @@ func mustJSON(val any) []byte {
 }
 
 // testStorageModeSetup creates a test config with the specified storage mode
-func testStorageModeSetup(t *testing.T, mode, storagePath string) (*Config, *ACMEIssuer, func()) {
+func testStorageModeSetup(t *testing.T, mode, storagePath string) (*Config, *ACMEIssuer) {
 	t.Helper()
-	originalEnv := os.Getenv(StorageModeEnv)
-	os.Setenv(StorageModeEnv, mode)
+	t.Setenv(StorageModeEnv, mode)
 
 	am := &ACMEIssuer{CA: "https://example.com/acme/directory"}
 	cfg := &Config{
@@ -170,12 +169,11 @@ func testStorageModeSetup(t *testing.T, mode, storagePath string) (*Config, *ACM
 	}
 	am.config = cfg
 
-	cleanup := func() {
-		os.Setenv(StorageModeEnv, originalEnv)
+	t.Cleanup(func() {
 		os.RemoveAll(storagePath)
-	}
+	})
 
-	return cfg, am, cleanup
+	return cfg, am
 }
 
 func makeCertResource(am *ACMEIssuer, domain string, useLegacyContent bool) CertificateResource {
@@ -214,8 +212,7 @@ func assertCertResourceContent(t *testing.T, loaded CertificateResource, expecte
 
 func TestStorageModeLegacy(t *testing.T) {
 	ctx := context.Background()
-	cfg, am, cleanup := testStorageModeSetup(t, StorageModeLegacy, "./_testdata_tmp_legacy")
-	defer cleanup()
+	cfg, am := testStorageModeSetup(t, StorageModeLegacy, "./_testdata_tmp_legacy")
 
 	domain := "example.com"
 	cert := makeCertResource(am, domain, true)
@@ -239,8 +236,7 @@ func TestStorageModeLegacy(t *testing.T) {
 
 func TestStorageModeBundle(t *testing.T) {
 	ctx := context.Background()
-	cfg, am, cleanup := testStorageModeSetup(t, StorageModeBundle, "./_testdata_tmp_bundle")
-	defer cleanup()
+	cfg, am := testStorageModeSetup(t, StorageModeBundle, "./_testdata_tmp_bundle")
 
 	domain := "example.com"
 	cert := makeCertResource(am, domain, false)
@@ -264,8 +260,7 @@ func TestStorageModeBundle(t *testing.T) {
 
 func TestStorageModeTransition(t *testing.T) {
 	ctx := context.Background()
-	cfg, am, cleanup := testStorageModeSetup(t, StorageModeTransition, "./_testdata_tmp_transition")
-	defer cleanup()
+	cfg, am := testStorageModeSetup(t, StorageModeTransition, "./_testdata_tmp_transition")
 
 	domain := "example.com"
 	cert := makeCertResource(am, domain, false)
@@ -290,8 +285,7 @@ func TestStorageModeTransition(t *testing.T) {
 
 func TestStorageModeTransitionFallback(t *testing.T) {
 	ctx := context.Background()
-	cfg, am, cleanup := testStorageModeSetup(t, StorageModeTransition, "./_testdata_tmp_transition_fallback")
-	defer cleanup()
+	cfg, am := testStorageModeSetup(t, StorageModeTransition, "./_testdata_tmp_transition_fallback")
 
 	domain := "example.com"
 	cert := makeCertResource(am, domain, true)

--- a/config_test.go
+++ b/config_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
-	"slices"
 	"testing"
 	"time"
 
@@ -79,68 +78,6 @@ func TestSaveCertResource(t *testing.T) {
 	}
 }
 
-func TestSaveCertResourceWithCertificateResourceStorage(t *testing.T) {
-	ctx := context.Background()
-
-	am := &ACMEIssuer{CA: "https://example.com/acme/directory"}
-	mockStore := &mockCertificateResourceStorage{
-		Storage: &FileStorage{Path: "./_testdata_tmp"},
-	}
-
-	testConfig := &Config{
-		Storage:   mockStore,
-		Issuers:   []Issuer{am},
-		Logger:    defaultTestLogger,
-		certCache: new(Cache),
-	}
-	am.config = testConfig
-
-	domain := "example.com"
-	certContents := "certificate"
-	keyContents := "private key"
-
-	cert := CertificateResource{
-		SANs:           []string{domain},
-		PrivateKeyPEM:  []byte(keyContents),
-		CertificatePEM: []byte(certContents),
-		IssuerData: mustJSON(acme.Certificate{
-			URL: "https://example.com/cert",
-		}),
-		issuerKey: am.IssuerKey(),
-	}
-
-	err := testConfig.saveCertResource(ctx, am, cert)
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
-
-	siteData, err := testConfig.loadCertResource(ctx, am, domain)
-	if err != nil {
-		t.Fatalf("Expected no error reading site, got: %v", err)
-	}
-
-	if !slices.Equal(cert.SANs, siteData.SANs) {
-		t.Fatalf("Expected SANs to be equal, want: %v, got: %v", cert.SANs, siteData.SANs)
-	}
-	if !bytes.Equal(cert.PrivateKeyPEM, siteData.PrivateKeyPEM) {
-		t.Fatalf("Expected PrivateKeyPEM to be equal, want: %v, got: %v", cert.SANs, siteData.SANs)
-	}
-	if !bytes.Equal(cert.CertificatePEM, siteData.CertificatePEM) {
-		t.Fatalf("Expected CertificatePEM to be equal, want: %v, got: %v", cert.SANs, siteData.SANs)
-	}
-	if !bytes.Equal(cert.IssuerData, siteData.IssuerData) {
-		t.Fatalf("Expected IssuerData to be equal, want: %v, got: %v", cert.SANs, siteData.SANs)
-	}
-
-	// Asserting internals is not ideal, but somehow we have to ensure interface promotion works correctly.
-	if mockStore.StoreCertificateResourceCalls != 1 {
-		t.Fatalf("Expected StoreCertificateResource to be called")
-	}
-	if mockStore.LoadCertificateResourceCalls != 1 {
-		t.Fatalf("Expected LoadCertificateResource to be called")
-	}
-}
-
 type mockStorageWithLease struct {
 	*FileStorage
 	renewCalled  bool
@@ -154,67 +91,6 @@ func (m *mockStorageWithLease) RenewLockLease(ctx context.Context, lockKey strin
 	m.lastLockKey = lockKey
 	m.lastDuration = leaseDuration
 	return m.renewError
-}
-
-type mockCertificateResourceStorage struct {
-	Storage
-
-	StoreCertificateResourceCalls int
-	LoadCertificateResourceCalls  int
-}
-
-func (s *mockCertificateResourceStorage) StoreCertificateResource(ctx context.Context, key string, res CertificateResource) error {
-	s.StoreCertificateResourceCalls++
-
-	// Some attributes in CertificateResource have the `json:"-"` tag,
-	// which is why we have to create a new struct for encoding.
-	resource := struct {
-		SANs           []string
-		CertificatePEM []byte
-		PrivateKeyPEM  []byte
-		IssuerData     json.RawMessage
-	}{
-		SANs:           res.SANs,
-		CertificatePEM: res.CertificatePEM,
-		PrivateKeyPEM:  res.PrivateKeyPEM,
-		IssuerData:     res.IssuerData,
-	}
-
-	buf, err := json.Marshal(resource)
-	if err != nil {
-		return err
-	}
-
-	return s.Storage.Store(ctx, key, buf)
-}
-
-func (s *mockCertificateResourceStorage) LoadCertificateResource(ctx context.Context, key string) (CertificateResource, error) {
-	s.LoadCertificateResourceCalls++
-
-	buf, err := s.Storage.Load(ctx, key)
-	if err != nil {
-		return CertificateResource{}, err
-	}
-
-	var resource struct {
-		SANs           []string
-		CertificatePEM []byte
-		PrivateKeyPEM  []byte
-		IssuerData     json.RawMessage
-	}
-
-	if err := json.Unmarshal(buf, &resource); err != nil {
-		return CertificateResource{}, err
-	}
-
-	res := CertificateResource{
-		SANs:           resource.SANs,
-		CertificatePEM: resource.CertificatePEM,
-		PrivateKeyPEM:  resource.PrivateKeyPEM,
-		IssuerData:     resource.IssuerData,
-	}
-
-	return res, nil
 }
 
 func TestRenewLockLeaseDuration(t *testing.T) {

--- a/crypto.go
+++ b/crypto.go
@@ -141,28 +141,6 @@ func fastHash(input []byte) string {
 	return fmt.Sprintf("%x", h.Sum32())
 }
 
-const (
-	// Storage mode controls the format in which certificates are stored in `Storage`.
-	//
-	// Formats:
-	// - legacy: Store cert, privkey and meta as three separate storage items (.cert, .key, .json).
-	// - bundle: Store cert, privkey and meta as a single, bundled storage item (.bundle).
-	//
-	// Modes:
-	// - legacy:     Store and load certificates in legacy format.
-	// - transition: Store and load certificates in legacy and bundle format.
-	// - bundle:     Store and load certificates in bundle format.
-	//
-	// In the transition mode, failures around reads and writes of the bundle are soft.
-	// They should only log errors and try to work with the legacy format as fallback.
-	// Operations on the legacy format are hard-failures, implying that errors should be propagated up.
-	StorageModeEnv = "CERTMAGIC_STORAGE_MODE"
-
-	StorageModeLegacy     = "legacy"
-	StorageModeTransition = "transition"
-	StorageModeBundle     = "bundle"
-)
-
 // saveCertResource saves the certificate resource to disk.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) saveCertResource(ctx context.Context, issuer Issuer, cert CertificateResource) error {

--- a/crypto.go
+++ b/crypto.go
@@ -34,7 +34,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/caarlos0/log"
 	"github.com/klauspost/cpuid/v2"
 	"github.com/zeebo/blake3"
 	"go.uber.org/zap"
@@ -160,7 +159,7 @@ func (cfg *Config) saveCertResource(ctx context.Context, issuer Issuer, cert Cer
 		// Errors that occured while storing the bundle will only be logged as warning.
 		// The legacy storage mechanism still determines the final success or failure.
 		if err := cfg.saveCertResourceBundle(ctx, issuer, cert); err != nil {
-			log.Warn("unable to store certificate resource bundle",
+			cfg.Logger.Warn("unable to store certificate resource bundle",
 				zap.String("issuer", issuer.IssuerKey()),
 				zap.String("domain", cert.NamesKey()),
 				zap.Error(err))
@@ -356,7 +355,7 @@ func (cfg *Config) loadCertResourceBundle(ctx context.Context, issuer Issuer, ce
 	}
 	certRes.issuerKey = issuer.IssuerKey()
 
-	if _, err := tls.X509KeyPair(certRes.PrivateKeyPEM, certRes.CertificatePEM); err != nil {
+	if _, err := tls.X509KeyPair(certRes.CertificatePEM, certRes.PrivateKeyPEM); err != nil {
 		return CertificateResource{}, fmt.Errorf("unable to validate integrity of certificate resource bundle for: %v", key)
 	}
 

--- a/crypto.go
+++ b/crypto.go
@@ -355,10 +355,6 @@ func (cfg *Config) loadCertResourceBundle(ctx context.Context, issuer Issuer, ce
 	}
 	certRes.issuerKey = issuer.IssuerKey()
 
-	if _, err := tls.X509KeyPair(certRes.CertificatePEM, certRes.PrivateKeyPEM); err != nil {
-		return CertificateResource{}, fmt.Errorf("unable to validate integrity of certificate resource bundle for %q: %w", key, err)
-	}
-
 	return certRes, nil
 }
 

--- a/crypto.go
+++ b/crypto.go
@@ -356,7 +356,7 @@ func (cfg *Config) loadCertResourceBundle(ctx context.Context, issuer Issuer, ce
 	certRes.issuerKey = issuer.IssuerKey()
 
 	if _, err := tls.X509KeyPair(certRes.CertificatePEM, certRes.PrivateKeyPEM); err != nil {
-		return CertificateResource{}, fmt.Errorf("unable to validate integrity of certificate resource bundle for: %v", key)
+		return CertificateResource{}, fmt.Errorf("unable to validate integrity of certificate resource bundle for %q: %w", key, err)
 	}
 
 	return certRes, nil

--- a/crypto.go
+++ b/crypto.go
@@ -142,6 +142,20 @@ func fastHash(input []byte) string {
 }
 
 const (
+	// Storage mode controls the format in which certificates are stored in `Storage`.
+	//
+	// Formats:
+	// - legacy: Store cert, privkey and meta as three separate storage items (.cert, .key, .json).
+	// - bundle: Store cert, privkey and meta as a single, bundled storage item (.bundle).
+	//
+	// Modes:
+	// - legacy:     Store and load certificates in legacy format.
+	// - transition: Store and load certificates in legacy and bundle format.
+	// - bundle:     Store and load certificates in bundle format.
+	//
+	// In the transition mode, failures around reads and writes of the bundle are soft.
+	// They should only log errors and try to work with the legacy format as fallback.
+	// Operations on the legacy format are hard-failures, implying that errors should be propagated up.
 	StorageModeEnv = "CERTMAGIC_STORAGE_MODE"
 
 	StorageModeLegacy     = "legacy"
@@ -216,7 +230,7 @@ func (cfg *Config) saveCertResourceBundle(ctx context.Context, issuer Issuer, ce
 	issuerKey := issuer.IssuerKey()
 	certKey := cert.NamesKey()
 
-	key := StorageKeys.CertificateResource(issuerKey, certKey)
+	key := StorageKeys.SiteBundle(issuerKey, certKey)
 	return cfg.Storage.Store(ctx, key, encoded)
 }
 

--- a/crypto.go
+++ b/crypto.go
@@ -271,6 +271,8 @@ func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey s
 	return certResources[0].CertificateResource, nil
 }
 
+// loadCertResource loads a certificate resource from the given issuer's storage location.
+// It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) loadCertResource(ctx context.Context, issuer Issuer, certNamesKey string) (CertificateResource, error) {
 	switch os.Getenv(StorageModeEnv) {
 	case StorageModeTransition:

--- a/maintain.go
+++ b/maintain.go
@@ -429,6 +429,7 @@ func (cfg *Config) storageHasNewerARI(ctx context.Context, cert Certificate) (bo
 }
 
 // loadStoredACMECertificateMetadata loads the stored ACME certificate data.
+// It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) loadStoredACMECertificateMetadata(ctx context.Context, cert Certificate) (acme.Certificate, error) {
 	switch os.Getenv(StorageModeEnv) {
 	case StorageModeTransition:
@@ -493,6 +494,7 @@ func (cfg *Config) loadStoredACMECertificateMetadataBundle(ctx context.Context, 
 //
 // This will always try to ARI without checking if it needs to be refreshed. Call
 // NeedsRefresh() on the RenewalInfo first, and only call this if that returns true.
+// It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) updateARI(ctx context.Context, cert Certificate, logger *zap.Logger) (updatedCert Certificate, changed bool, err error) {
 	switch os.Getenv(StorageModeEnv) {
 	case StorageModeTransition:

--- a/storage.go
+++ b/storage.go
@@ -255,7 +255,7 @@ func (keys KeyBuilder) SiteMeta(issuerKey, domain string) string {
 // the given issuerKey.
 func (keys KeyBuilder) CertificateResource(issuerKey, domain string) string {
 	safeDomain := keys.Safe(domain)
-	return path.Join(keys.CertsSitePrefix(issuerKey, domain), safeDomain+".res")
+	return path.Join(keys.CertsSitePrefix(issuerKey, domain), safeDomain+".bundle")
 }
 
 // OCSPStaple returns a key for the OCSP staple associated

--- a/storage.go
+++ b/storage.go
@@ -104,18 +104,6 @@ type Storage interface {
 	Stat(ctx context.Context, key string) (KeyInfo, error)
 }
 
-// CertificateResourceStorage adds helpers for storing and loading
-// CertificateResource values. Implementations should serialize the
-// resource to a consistent format.
-type CertificateResourceStorage interface {
-	// StoreCertificateResource stores the certificate resource at key,
-	// overwriting any existing value.
-	StoreCertificateResource(ctx context.Context, key string, res CertificateResource) error
-
-	// LoadCertificateResource loads the certificate resource at key.
-	LoadCertificateResource(ctx context.Context, key string) (CertificateResource, error)
-}
-
 // Locker facilitates synchronization across machines and networks.
 // It essentially provides a distributed named-mutex service so
 // that multiple consumers can coordinate tasks and share resources.

--- a/storage.go
+++ b/storage.go
@@ -250,10 +250,10 @@ func (keys KeyBuilder) SiteMeta(issuerKey, domain string) string {
 	return path.Join(keys.CertsSitePrefix(issuerKey, domain), safeDomain+".json")
 }
 
-// CertificateResource returns the path to the resource file for domain that
+// SiteBundle returns the path to the resource file for domain that
 // is associated with the certificate from the given issuer with
 // the given issuerKey.
-func (keys KeyBuilder) CertificateResource(issuerKey, domain string) string {
+func (keys KeyBuilder) SiteBundle(issuerKey, domain string) string {
 	safeDomain := keys.Safe(domain)
 	return path.Join(keys.CertsSitePrefix(issuerKey, domain), safeDomain+".bundle")
 }


### PR DESCRIPTION
## How certmagic currently stores certs

In certmagic, a certificate consists of three different entities: 
- Certificate (.crt) 
- Private key (.key)
- Meta data (issuer and renewal details) (.json)

These entities are stored and retrieved individually using the `.Load()` and `.Store()` functions, when obtaining or renewing a cert.

## Problem

The current implementation has two important problems:
- Storing and loading certificates and private keys are non-atomic operations, causing this issue:
  - https://github.com/framer/company/issues/27838 
- Failing to store one entitiy can cause other entiries to be deleted.
  - https://github.com/framer/certmagic/blob/20b57b0b0d73715896347e80f214e21336d59f6a/storage.go#L193-L205

## Solution

This change adresses the issue by storing all three entities as a single certificate bundle (.bundle).

As we're operating on a database with live certificates, this change also introduces the concept of a storage mode, that allows for seemless migration from the old to the new storage format:

```go
const (
	// Storage mode controls the format in which certificates are stored in `Storage`.
	//
	// Formats:
	// - legacy: Store cert, privkey and meta as three separate storage items (.cert, .key, .json).
	// - bundle: Store cert, privkey and meta as a single, bundled storage item (.bundle).
	//
	// Modes:
	// - legacy:     Store and load certificates in legacy format.
	// - transition: Store and load certificates in legacy and bundle format.
	// - bundle:     Store and load certificates in bundle format.
	//
	// In the transition mode, failures around reads and writes of the bundle are soft.
	// They should only log errors and try to work with the legacy format as fallback.
	// Operations on the legacy format are hard-failures, implying that errors should be propagated up.
	//
	// The storage mode is controlled via the CERTMAGIC_STORAGE_MODE environment variable
	StorageModeEnv = "CERTMAGIC_STORAGE_MODE"

	StorageModeLegacy     = "legacy"
	StorageModeTransition = "transition"
	StorageModeBundle     = "bundle"
)
```

## REVIEW DISCLAIMER

I did not try to be smart about the alternate storage implementation:
- Most of the functions that interacted with `Storage` have been duplicated and updated.
- For all those function, a feature flag switch was added.
- I refrained from abstracting the storage logic further.
- With that we can still integrate any upstream changes from certmagic easily.
- This leaves also us the easy option of removing all `...Legacy` functions after a full switch.

This is pretty much the calling sequence for all functions that do storage things:

```go
// ---------------------------
// BEFORE
// ---------------------------
func storeCertResource(...) {
    // store crt, key, meta
}
```
```go
// ---------------------------
// AFTER
// ---------------------------
func storeCertResource(...) { // keeps the original function signature
    switch storageMode {
    case "legacy": 
        storeCertResourceLegacy(...)

    case "transition":
        storeCertResourceLegacy(...)
        storeCertResourceBundle(...)

    case "bundle":
        storeCertResourceBundle(...)
    }
}

func storeCertResourceLegacy(...) { // the original unmodified function
    // store crt, key, meta
}

func storeCertResourceLegacy(...) { // the original function but with bundle format
    // store bundle
}
```