### PR TITLE
Add capability for gradual rollout of transition mode

### DIFF
--- a/certmagic.go
+++ b/certmagic.go
@@ -499,27 +499,3 @@ var (
 
 // Maximum size for the stack trace when recovering from panics.
 const stackTraceBufferSize = 1024 * 128
-
-const (
-	// Storage mode controls the format in which certificates are stored in `Storage`.
-	//
-	// Formats:
-	// - legacy: Store cert, privkey and meta as three separate storage items (.cert, .key, .json).
-	// - bundle: Store cert, privkey and meta as a single, bundled storage item (.bundle).
-	//
-	// Modes:
-	// - legacy:     Store and load certificates in legacy format.
-	// - transition: Store in legacy and bundle format, load as bundle with fallback to legacy format.
-	// - bundle:     Store and load certificates in bundle format.
-	//
-	// In the transition mode, failures around reads and writes of the bundle are soft.
-	// They should only log errors and try to work with the legacy format as fallback.
-	// Operations on the legacy format are hard-failures, implying that errors should be propagated up.
-	//
-	// The storage mode is controlled via the CERTMAGIC_STORAGE_MODE environment variable
-	StorageModeEnv = "CERTMAGIC_STORAGE_MODE"
-
-	StorageModeLegacy     = "legacy"
-	StorageModeTransition = "transition"
-	StorageModeBundle     = "bundle"
-)

--- a/config.go
+++ b/config.go
@@ -32,7 +32,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -1272,7 +1271,7 @@ func (cfg *Config) checkStorage(ctx context.Context) error {
 // resources related to the certificate for domain.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) storageHasCertResources(ctx context.Context, issuer Issuer, domain string) bool {
-	switch os.Getenv(StorageModeEnv) {
+	switch StorageModeForDomain(domain) {
 	case StorageModeTransition:
 		if cfg.storageHasCertResourcesBundle(ctx, issuer, domain) {
 			return true
@@ -1313,7 +1312,7 @@ func (cfg *Config) storageHasCertResourcesBundle(ctx context.Context, issuer Iss
 // issuer with the given issuer key.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) deleteSiteAssets(ctx context.Context, issuerKey, domain string) error {
-	switch os.Getenv(StorageModeEnv) {
+	switch StorageModeForDomain(domain) {
 	case StorageModeTransition:
 		if err := cfg.deleteSiteAssetsBundle(ctx, issuerKey, domain); err != nil {
 			cfg.Logger.Warn("unable to delete certificate resource bundle",

--- a/config.go
+++ b/config.go
@@ -1271,7 +1271,12 @@ func (cfg *Config) checkStorage(ctx context.Context) error {
 // resources related to the certificate for domain.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) storageHasCertResources(ctx context.Context, issuer Issuer, domain string) bool {
-	switch StorageModeForDomain(domain) {
+	storageMode := StorageModeForDomain(domain)
+	cfg.Logger.Debug("checking if storage has cert resources",
+		zap.String("domain", domain),
+		zap.String("storage_mode", storageMode),
+		zap.Int("rollout_bucket", RolloutBucketForDomain(domain)))
+	switch storageMode {
 	case StorageModeTransition:
 		if cfg.storageHasCertResourcesBundle(ctx, issuer, domain) {
 			return true
@@ -1312,7 +1317,12 @@ func (cfg *Config) storageHasCertResourcesBundle(ctx context.Context, issuer Iss
 // issuer with the given issuer key.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) deleteSiteAssets(ctx context.Context, issuerKey, domain string) error {
-	switch StorageModeForDomain(domain) {
+	storageMode := StorageModeForDomain(domain)
+	cfg.Logger.Debug("deleting site assets",
+		zap.String("domain", domain),
+		zap.String("storage_mode", storageMode),
+		zap.Int("rollout_bucket", RolloutBucketForDomain(domain)))
+	switch storageMode {
 	case StorageModeTransition:
 		if err := cfg.deleteSiteAssetsBundle(ctx, issuerKey, domain); err != nil {
 			cfg.Logger.Warn("unable to delete certificate resource bundle",

--- a/config_test.go
+++ b/config_test.go
@@ -158,7 +158,7 @@ func mustJSON(val any) []byte {
 // testStorageModeSetup creates a test config with the specified storage mode
 func testStorageModeSetup(t *testing.T, mode, storagePath string) (*Config, *ACMEIssuer) {
 	t.Helper()
-	t.Setenv(StorageModeEnv, mode)
+	ConfigureStorageMode(mode, 100)
 
 	am := &ACMEIssuer{CA: "https://example.com/acme/directory"}
 	cfg := &Config{
@@ -291,7 +291,7 @@ func TestStorageModeTransitionFallback(t *testing.T) {
 	cert := makeCertResource(am, domain, true)
 
 	// Save in legacy mode to simulate existing data
-	os.Setenv(StorageModeEnv, StorageModeLegacy)
+	ConfigureStorageMode(StorageModeLegacy, 0)
 	if err := cfg.saveCertResource(ctx, am, cert); err != nil {
 		t.Fatalf("Failed to save cert in legacy mode: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestStorageModeTransitionFallback(t *testing.T) {
 	assertFileNotExists(t, ctx, cfg.Storage, StorageKeys.SiteBundle(issuerKey, domain))
 
 	// Switch to transition mode and verify fallback to legacy works
-	os.Setenv(StorageModeEnv, StorageModeTransition)
+	ConfigureStorageMode(StorageModeTransition, 100)
 	loaded, err := cfg.loadCertResource(ctx, am, domain)
 	if err != nil {
 		t.Fatalf("Failed to load cert in transition mode with fallback: %v", err)

--- a/crypto.go
+++ b/crypto.go
@@ -143,12 +143,12 @@ func fastHash(input []byte) string {
 // saveCertResource saves the certificate resource to disk.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) saveCertResource(ctx context.Context, issuer Issuer, cert CertificateResource) error {
-	switch StorageModeForDomain(cert.NamesKey()) {
+	switch StorageModeForDomain(cert.SANs[0]) {
 	case StorageModeTransition:
 		if err := cfg.saveCertResourceBundle(ctx, issuer, cert); err != nil {
 			cfg.Logger.Warn("unable to store certificate resource bundle",
 				zap.String("issuer", issuer.IssuerKey()),
-				zap.String("domain", cert.NamesKey()),
+				zap.String("domain", cert.SANs[0]),
 				zap.Error(err))
 		}
 		return cfg.saveCertResourceLegacy(ctx, issuer, cert)

--- a/crypto.go
+++ b/crypto.go
@@ -143,7 +143,12 @@ func fastHash(input []byte) string {
 // saveCertResource saves the certificate resource to disk.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) saveCertResource(ctx context.Context, issuer Issuer, cert CertificateResource) error {
-	switch StorageModeForDomain(cert.SANs[0]) {
+	storageMode := StorageModeForDomain(cert.SANs[0])
+	cfg.Logger.Debug("saving certificate resource",
+		zap.String("domain", cert.SANs[0]),
+		zap.String("storage_mode", storageMode),
+		zap.Int("rollout_bucket", RolloutBucketForDomain(cert.SANs[0])))
+	switch storageMode {
 	case StorageModeTransition:
 		if err := cfg.saveCertResourceBundle(ctx, issuer, cert); err != nil {
 			cfg.Logger.Warn("unable to store certificate resource bundle",
@@ -273,7 +278,12 @@ func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey s
 // loadCertResource loads a certificate resource from the given issuer's storage location.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) loadCertResource(ctx context.Context, issuer Issuer, certNamesKey string) (CertificateResource, error) {
-	switch StorageModeForDomain(certNamesKey) {
+	storageMode := StorageModeForDomain(certNamesKey)
+	cfg.Logger.Debug("loading certificate resource",
+		zap.String("domain", certNamesKey),
+		zap.String("storage_mode", storageMode),
+		zap.Int("rollout_bucket", RolloutBucketForDomain(certNamesKey)))
+	switch storageMode {
 	case StorageModeTransition:
 		certRes, err := cfg.loadCertResourceBundle(ctx, issuer, certNamesKey)
 		if err == nil {

--- a/crypto.go
+++ b/crypto.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io/fs"
-	"os"
 	"sort"
 	"strings"
 
@@ -144,7 +143,7 @@ func fastHash(input []byte) string {
 // saveCertResource saves the certificate resource to disk.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) saveCertResource(ctx context.Context, issuer Issuer, cert CertificateResource) error {
-	switch os.Getenv(StorageModeEnv) {
+	switch StorageModeForDomain(cert.NamesKey()) {
 	case StorageModeTransition:
 		if err := cfg.saveCertResourceBundle(ctx, issuer, cert); err != nil {
 			cfg.Logger.Warn("unable to store certificate resource bundle",
@@ -274,7 +273,7 @@ func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey s
 // loadCertResource loads a certificate resource from the given issuer's storage location.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) loadCertResource(ctx context.Context, issuer Issuer, certNamesKey string) (CertificateResource, error) {
-	switch os.Getenv(StorageModeEnv) {
+	switch StorageModeForDomain(certNamesKey) {
 	case StorageModeTransition:
 		certRes, err := cfg.loadCertResourceBundle(ctx, issuer, certNamesKey)
 		if err == nil {

--- a/maintain.go
+++ b/maintain.go
@@ -430,7 +430,12 @@ func (cfg *Config) storageHasNewerARI(ctx context.Context, cert Certificate) (bo
 // loadStoredACMECertificateMetadata loads the stored ACME certificate data.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) loadStoredACMECertificateMetadata(ctx context.Context, cert Certificate) (acme.Certificate, error) {
-	switch StorageModeForDomain(cert.Names[0]) {
+	storageMode := StorageModeForDomain(cert.Names[0])
+	cfg.Logger.Debug("loading stored ACME certificate metadata",
+		zap.String("domain", cert.Names[0]),
+		zap.String("storage_mode", storageMode),
+		zap.Int("rollout_bucket", RolloutBucketForDomain(cert.Names[0])))
+	switch storageMode {
 	case StorageModeTransition:
 		acmecert, err := cfg.loadStoredACMECertificateMetadataBundle(ctx, cert)
 		if err == nil {
@@ -495,7 +500,12 @@ func (cfg *Config) loadStoredACMECertificateMetadataBundle(ctx context.Context, 
 // NeedsRefresh() on the RenewalInfo first, and only call this if that returns true.
 // It switches storage modes between legacy and bundle mode based on the CERTMAGIC_STORAGE_MODE env.
 func (cfg *Config) updateARI(ctx context.Context, cert Certificate, logger *zap.Logger) (updatedCert Certificate, changed bool, err error) {
-	switch StorageModeForDomain(cert.Names[0]) {
+	storageMode := StorageModeForDomain(cert.Names[0])
+	cfg.Logger.Debug("updating ARI",
+		zap.String("domain", cert.Names[0]),
+		zap.String("storage_mode", storageMode),
+		zap.Int("rollout_bucket", RolloutBucketForDomain(cert.Names[0])))
+	switch storageMode {
 	case StorageModeTransition:
 		updatedCert, changed, err = cfg.updateARILegacy(ctx, cert, logger)
 		if err == nil {
@@ -1045,6 +1055,7 @@ func deleteOldOCSPStaples(ctx context.Context, storage Storage, logger *zap.Logg
 }
 
 func deleteExpiredCerts(ctx context.Context, storage Storage, logger *zap.Logger, gracePeriod time.Duration) error {
+	logger.Debug("deleting expired certs", zap.String("storage_mode", StorageMode))
 	switch StorageMode {
 	case StorageModeTransition:
 		if err := deleteExpiredCertsBundle(ctx, storage, logger, gracePeriod); err != nil {
@@ -1320,7 +1331,12 @@ func (cfg *Config) moveCompromisedPrivateKey(ctx context.Context, cert Certifica
 	// Delete the storage containing the compromised key based on storage mode.
 	// We intentionally ignore delete errors since the file might not exist,
 	// and we avoid calling .Exists() before .Delete() to minimize storage roundtrips.
-	switch StorageModeForDomain(cert.Names[0]) {
+	storageMode := StorageModeForDomain(cert.Names[0])
+	logger.Debug("deleting compromised private key",
+		zap.String("domain", cert.Names[0]),
+		zap.String("storage_mode", storageMode),
+		zap.Int("rollout_bucket", RolloutBucketForDomain(cert.Names[0])))
+	switch storageMode {
 	case StorageModeTransition:
 		cfg.Storage.Delete(ctx, bundleKey)
 		cfg.Storage.Delete(ctx, privKeyStorageKey)

--- a/storagemode.go
+++ b/storagemode.go
@@ -1,0 +1,85 @@
+package certmagic
+
+import (
+	"hash/fnv"
+	"os"
+	"strconv"
+)
+
+const (
+	// Storage mode controls the format in which certificates are stored in `Storage`.
+	//
+	// Formats:
+	// - legacy: Store cert, privkey and meta as three separate storage items (.cert, .key, .json).
+	// - bundle: Store cert, privkey and meta as a single, bundled storage item (.bundle).
+	//
+	// Modes:
+	// - legacy:     Store and load certificates in legacy format.
+	// - transition: Store in legacy and bundle format, load as bundle with fallback to legacy format.
+	// - bundle:      Store and load certificates in bundle format.
+	//
+	// In the transition mode, failures around reads and writes of the bundle are soft.
+	// They should only log errors and try to work with the legacy format as fallback.
+	// Operations on the legacy format are hard-failures, implying that errors should be propagated up.
+	//
+	// The rollout percentage enables a phased migration by controlling which domains
+	// enter the transition phase. If a domain's deterministic bucket (0-99) is below
+	// the rollout percentage, it uses 'transition' mode (dual-write, bundle-read).
+	// Otherwise, it remains in 'legacy' mode.
+	//
+	// The logic for selection is:
+	//   if mode == StorageModeTransition:
+	//       useTransition = hash(domain)%100 < rollout
+	//       return useTransition ? StorageModeTransition : StorageModeLegacy
+	//
+	// The storage mode is controlled via the CERTMAGIC_STORAGE_MODE environment variable
+	StorageModeEnv = "CERTMAGIC_STORAGE_MODE"
+
+	StorageModeLegacy     = "legacy"
+	StorageModeTransition = "transition"
+	StorageModeBundle     = "bundle"
+
+	// StorageModeRolloutPercentEnv controls the percentage of domains that will use
+	// the bundle format when the storage mode is set to "transition".
+	// An empty rollout precent is equal to 0%.
+	StorageModeRolloutPercentEnv = "CERTMAGIC_STORAGE_MODE_ROLLOUT_PERCENT"
+)
+
+var (
+	StorageMode               string
+	StorageModeRolloutPercent int
+)
+
+func ConfigureStorageMode(mode string, rolloutPercent int) {
+	StorageMode = mode
+	StorageModeRolloutPercent = rolloutPercent
+}
+
+func init() {
+	mode := os.Getenv(StorageModeEnv)
+
+	// rolloutPercent becomes zero if env is unset or malformed
+	rolloutPercent, _ := strconv.Atoi(os.Getenv(StorageModeRolloutPercentEnv))
+
+	ConfigureStorageMode(mode, rolloutPercent)
+}
+
+func StorageModeForDomain(domain string) string {
+	if StorageMode == StorageModeBundle {
+		return StorageModeBundle
+	}
+	if StorageMode != StorageModeTransition {
+		return StorageModeLegacy
+	}
+	if RolloutBucketForDomain(domain) < StorageModeRolloutPercent {
+		return StorageModeTransition
+	} else {
+		return StorageModeLegacy
+	}
+}
+
+func RolloutBucketForDomain(domain string) int {
+	h := fnv.New32a()
+	h.Write([]byte(domain))
+	return int(h.Sum32() % 100)
+}

--- a/storagemode.go
+++ b/storagemode.go
@@ -51,6 +51,8 @@ var (
 )
 
 func ConfigureStorageMode(mode string, rolloutPercent int) {
+	// Note: We have no lock protecting these variables. This is a potential race condition, yes.
+	// But this function is only called once during init(), before anything else happens.
 	StorageMode = mode
 	StorageModeRolloutPercent = rolloutPercent
 }

--- a/storagemode_test.go
+++ b/storagemode_test.go
@@ -1,0 +1,192 @@
+package certmagic
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
+
+func TestStorageModeRolloutPercentLegacy(t *testing.T) {
+	// In legacy mode, storage mode for all domains must be "legacy", no matter the rollout percent.
+	// This test brute-forces all possible test cases, as they are cheap to assert.
+	for rolloutPercent := range 100 {
+		ConfigureStorageMode(StorageModeLegacy, rolloutPercent)
+
+		for _, domain := range testStorageModeDomains {
+			want, got := StorageModeLegacy, StorageModeForDomain(domain)
+			if want != got {
+				t.Errorf("expected storage mode %q for domain %q, got: %q", want, domain, got)
+			}
+		}
+	}
+}
+
+func TestStorageModeRolloutPercentBundle(t *testing.T) {
+	// In legacy mode, storage mode for all domains must be "legacy", no matter the rollout percent.
+	// This test brute-forces all possible test cases, as they are cheap to assert.
+	for rolloutPercent := range 100 {
+		ConfigureStorageMode(StorageModeBundle, rolloutPercent)
+
+		for _, domain := range testStorageModeDomains {
+			want, got := StorageModeBundle, StorageModeForDomain(domain)
+			if want != got {
+				t.Errorf("expected storage mode %q for domain %q, got: %q", want, domain, got)
+			}
+		}
+	}
+}
+
+func TestStorageModeRolloutPercentTransition(t *testing.T) {
+	// In transition mode, storage mode for domains can either be "transition" or "legacy", depending on rollout percent.
+	// This test brute-forces all possible test cases, as they are cheap to assert.
+	for rolloutPercent := range 100 {
+		ConfigureStorageMode(StorageModeTransition, rolloutPercent)
+
+		for domainBucket, domain := range testStorageModeDomains {
+			got := StorageModeForDomain(domain)
+
+			var want string
+			if domainBucket < rolloutPercent {
+				want = StorageModeTransition
+			} else {
+				want = StorageModeLegacy
+			}
+
+			if want != got {
+				t.Errorf("expected storage mode %q for domain %q, got: %q", want, domain, got)
+			}
+		}
+	}
+}
+
+func GenerateRandomDomainsForRolloutBuckets(t *testing.T) {
+	for desiredBucket := range 100 {
+		for {
+			domain := RandomDomain()
+			bucket := RolloutBucketForDomain(domain)
+			if desiredBucket == bucket {
+				fmt.Println(domain, bucket)
+				break
+			}
+		}
+	}
+}
+
+func RandomDomain() string {
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
+	src := make([]byte, 6)
+	rand.Read(src)
+	for i := range src {
+		src[i] = alphabet[src[i]%26]
+	}
+	return string(src) + ".com"
+}
+
+// testStorageModeDomains are domains whose hashes are deterministic.
+// Example:
+// - Domain at index 0 hashes to bucket 0
+// - Domain at index 1 hashes to bucket 1
+// - Domain at index 2 hashes to bucket 2
+// - ...
+var testStorageModeDomains = []string{
+	"cyufsv.com",
+	"wrgmsg.com",
+	"brgdjo.com",
+	"ydwcck.com",
+	"mflmhz.com",
+	"haegjj.com",
+	"zmhovf.com",
+	"obufpu.com",
+	"feslvv.com",
+	"sebycw.com",
+	"eilifq.com",
+	"hqbrqi.com",
+	"msdfdl.com",
+	"zzyzeg.com",
+	"omkufr.com",
+	"wxknzs.com",
+	"sbrjrs.com",
+	"oirmum.com",
+	"ahkfmk.com",
+	"pasrgp.com",
+	"wkxoax.com",
+	"hrften.com",
+	"awvybq.com",
+	"sdnroo.com",
+	"oihglq.com",
+	"ilomtn.com",
+	"jsslsa.com",
+	"xfqsqj.com",
+	"seccht.com",
+	"kdggrx.com",
+	"htueua.com",
+	"rwnblj.com",
+	"muuiye.com",
+	"dmgdwl.com",
+	"ehcpua.com",
+	"hheskv.com",
+	"xapqrp.com",
+	"rtqlga.com",
+	"zwejrb.com",
+	"caijym.com",
+	"qqobjq.com",
+	"ylhtvl.com",
+	"leotig.com",
+	"xzzdkn.com",
+	"gtbrls.com",
+	"ffdfon.com",
+	"yndvoz.com",
+	"pcdete.com",
+	"mqqawg.com",
+	"cdbbdh.com",
+	"lgxeeu.com",
+	"hwqhre.com",
+	"glzlpq.com",
+	"wmogra.com",
+	"cdrpnm.com",
+	"idrfwa.com",
+	"ktrubn.com",
+	"xohmsv.com",
+	"mmddcs.com",
+	"mlmgvj.com",
+	"myxcwb.com",
+	"rrlbbu.com",
+	"abifcu.com",
+	"uarnen.com",
+	"utvepr.com",
+	"hvriwm.com",
+	"ktoobi.com",
+	"pkucoi.com",
+	"enszeo.com",
+	"boerwx.com",
+	"oftmjp.com",
+	"conpid.com",
+	"xsixnx.com",
+	"acbdut.com",
+	"oipdfz.com",
+	"cceope.com",
+	"shyuyj.com",
+	"flddpw.com",
+	"hmdtxy.com",
+	"lsfqfe.com",
+	"ynmpsm.com",
+	"kbkkbn.com",
+	"xrerap.com",
+	"dhhhkr.com",
+	"zdbnpt.com",
+	"ttxvat.com",
+	"rkrnjg.com",
+	"xkanxi.com",
+	"nbcmqi.com",
+	"mmhner.com",
+	"elunlf.com",
+	"bjupxh.com",
+	"loosax.com",
+	"fliwby.com",
+	"kjelwq.com",
+	"nlcgov.com",
+	"jjxavu.com",
+	"gpalyx.com",
+	"ckycee.com",
+	"msngsw.com",
+}


### PR DESCRIPTION
This PR introduces a way to gradually roll out the new certificate storage format. Instead of switching every domain to the new system at once, we can now move them over in small groups to ensure everything is working correctly.

## Percentage-Based Rollout

- The new setting, `CERTMAGIC_STORAGE_MODE_ROLLOUT_PERCENT` allows us to control the amount of domains which enter "transition" mode.
- CertMagic looks at each domain name and assigns it to a "bucket" from 0 to 100 using a hash function. 
- So when can set the rollout to e.g. `10`, only 10% of all domains fall into the "rollout buckets" and enter transition mode.
- Because this is based on the domain name itself, the same domain will always land in the same bucket. 

## Why this is helpful

- We can start with a 1% rollout to monitor for any storage errors before committing to 100%.
- Since the decision is deterministic (based on the name), a domain won't accidentally flip-flop between formats.
- If we don't set a percentage, it defaults to 0. This means no behavior changes for our existing setup until we are ready to start the migration.

## Notes

- We should only ever increase the rollout percentage, never decrease, to avoid inconsistencies bundle formats.

## Proof of work

### ROLLOUT_PERCENT = 40

1. Domains in buckets < 40 go into transition mode
2. Domains in buckets >= 50 stay in legacy mode

<img width="2326" height="858" alt="image" src="https://github.com/user-attachments/assets/cc6446d6-cd95-4f61-904b-b95a4d7a07b1" />

### ROLLOUT_PERCENT = 0

1. All domains stay in legacy mode

<img width="2320" height="474" alt="image" src="https://github.com/user-attachments/assets/493b3d7c-0574-4805-b2e1-6bb9931dc57f" />

### ROLLOUT_PERCENT = 100

1. All domains go into transition mode

<img width="2362" height="518" alt="image" src="https://github.com/user-attachments/assets/345f5dcc-d508-49b0-b039-feb0f6ac1576" />
